### PR TITLE
feat: Add permissions form success state

### DIFF
--- a/src/css/options.css
+++ b/src/css/options.css
@@ -209,3 +209,9 @@ input[type='button']:disabled {
 #savePermissions {
   margin-top: 30px;
 }
+
+#permissions_form > section {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}

--- a/src/options.html
+++ b/src/options.html
@@ -337,15 +337,22 @@
         </div>
 
         <form id="permissions_form">
-            <div>
-              <input type="checkbox" name="user_is_18_plus" />
-              <label for="user_is_18_plus">Мені 18 або більше</label>
-            </div>
-            <div>
-              <input type="checkbox" name="collect_stats" disabled />
-              <label for="collect_stats">Дозволяю збирати статистику</label> <br />
-            </div>
-          <input type="submit" value="Зберегти" id="saveAllPrefs" class="hidden" />
+          <div>
+            <input type="checkbox" name="user_is_18_plus" />
+            <label for="user_is_18_plus">Мені 18 або більше</label>
+          </div>
+          <div>
+            <input type="checkbox" name="collect_stats" disabled />
+            <label for="collect_stats">Дозволяю збирати статистику</label> <br />
+          </div>
+          <section>
+            <input type="submit" value="Зберегти" id="saveAllPrefs" class="hidden" />
+            <section id="permissionFormSuccess" class="hidden">
+              <p>
+                Зміни збережено
+              </p>
+            </section>
+          </section>
         </form>
       </section>
 


### PR DESCRIPTION
# Description
Add the success copy for the user permissions form so it's clear the changes have been saved.

In order to add this in, I had to do a small refactoring to the `saveLangChoice` function.

Hope Tim Cook will be happy with this addition. 😂

# Screenshot

https://user-images.githubusercontent.com/1335019/171537965-4dbabb7d-0d1a-44c0-abee-207b60678bad.mov

Closes #17 

